### PR TITLE
fix: pass through timestamp with event results

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Parameters:
 
 Emits an event called `predict` with arguments:
 > `uuid`: UUID of caller  
+> `timestamp`: timestamp of chunk of data
 >`p300`: either True or False, predicting whether there is a P300 ERP  
 >`score`: a value from 0 to 1 denoting the confidence in the prediction
 
@@ -158,8 +159,9 @@ Parameters:
 >`p300`: either True or False (or 1 or 0), depending on whether there should be a P300 ERP
 
 Emits an event called `train` with arguments:
-> `uuid`: UUID of caller  
-`acc`: accuracy of current classifier. This is either None/null (not enough training samples for training), or a number between 0 and 1.
+> `uuid`: UUID of caller 
+> `timestamp`: timestamp of chunk of data 
+> `acc`: accuracy of current classifier. This is either None/null (not enough training samples for training), or a number between 0 and 1.
 
 <br/>
 
@@ -168,12 +170,13 @@ Make a prediction for whether the user is using their left or right brain at a t
 
 Parameters:
 > `uuid`: UUID of whoever is making a prediction. This will determine which classifier we will load up and use.  
-`timestamp`: timestamp of chunk of data
+> `timestamp`: timestamp of chunk of data
 
 Emits an event called `predict` with arguments:
 > `uuid`: UUID of caller  
-`left`: either True or False, predicting whether the user is using their left (True) or right (False) brain  
-`score`: a value from 0 to 1 denoting the confidence in the prediction
+> `timestamp`: timestamp of chunk of data
+> `left`: either True or False, predicting whether the user is using their left (True) or right (False) brain  
+> `score`: a value from 0 to 1 denoting the confidence in the prediction
 
 <br/>
 
@@ -182,9 +185,10 @@ Give a training example to the left/right brain classifier.
 
 Parameters:
 > `uuid`: UUID of whoever is making a prediction. This will determine which classifier we will load up and use.  
-`timestamp`: timestamp of chunk of data  
-`left`: True if using left brain, or False if using right brain
+> `timestamp`: timestamp of chunk of data  
+> `left`: True if using left brain, or False if using right brain
 
 Emits an event called `train` with arguments:
 > `uuid`: UUID of caller  
->`acc`: accuracy of current classifier. This is either None/null (not enough training samples for training), or a number between 0 and 1.
+> `timestamp`: timestamp of chunk of data
+> `acc`: accuracy of current classifier. This is either None/null (not enough training samples for training), or a number between 0 and 1.

--- a/neurostack/server/services/left_right.py
+++ b/neurostack/server/services/left_right.py
@@ -77,6 +77,7 @@ class LeftRightService(BaseService):
 
         results = {
             'uuid': uuid,
+            'timestamp': timestamp,
             'acc': None
         }
 
@@ -124,9 +125,10 @@ class LeftRightService(BaseService):
         else:
             return 'Cannot load classifier and make prediction'
 
-        # currently we do not have a confidence method
+        # TODO: include 'score' (currently we do not have a confidence method)
         results = {
             'uuid': uuid,
+            'timestamp': timestamp,
             'left': left
         }
         return results

--- a/neurostack/server/services/p300.py
+++ b/neurostack/server/services/p300.py
@@ -25,6 +25,7 @@ class P300Service(BaseService):
 
         results = {
             'uuid': uuid,
+            'timestamp': timestamp,
             'acc': None
         }
 
@@ -73,6 +74,7 @@ class P300Service(BaseService):
         score = 1
         results = {
             'uuid': uuid,
+            'timestamp': timestamp,
             'p300': int(p300),
             'score': score
         }


### PR DESCRIPTION
**Overall Changes:** Passing through the timestamp for all websocket events

**Reason for Changes:**

- For each of these events, we are being told the results of a particular piece of data
    - Remember that these events could be sent out rapidly by the client & are not guaranteed to be handled & sent back in the order they are received
    - As a result, it is very important for clients that we tell them which data we have done prediction on (which is uniquely identified by uuid + timestamp)
- Design note: any communication like this lends itself better to be an HTTP request (rather than a websocket)
    - Reasoning: the services are initiated by the user & demand that each request has a corresponding response